### PR TITLE
fix function buildParameters

### DIFF
--- a/src/core/queryGeneration.js
+++ b/src/core/queryGeneration.js
@@ -29,7 +29,7 @@ const createIndent = (spaces: number): string =>
 const buildParameters = (params: ?Object): string => {
 	params = _.pickBy(params || {}, value => value !== null && value !== undefined && !Object.is(value, NaN))
 	if (_.isEmpty(params)) return ""
-	return `(${_.map(_.pickBy(params, param => param || param === false), (param, key) =>
+	return `(${_.map(params, (param, key) =>
 		`${key}: ${JSON.stringify(param).replace(/"([^(")"]+)":/g, "$1:")}`)})`
 }
 


### PR DESCRIPTION
fix function buildParameters omits key-value pair in params when the value is equal to zero.